### PR TITLE
chore: remove misnamed docs/ci.yaml (Tome lives under docs/tome)

### DIFF
--- a/docs/ci.yaml
+++ b/docs/ci.yaml
@@ -1,1 +1,0 @@
-Moved: see docs/governance/civic_tome.md (this file was misnamed and kept only to avoid breaking links; safe to delete).


### PR DESCRIPTION
## Summary
<one-liner>

## Intent & Pillars
- **Intent:** <why this change exists>
- **Pillars:** <Orchestration | Tome | Penumbra | Astris/Auctor | UCF | Pilot>

## Changes
- [ ] Docs updated
- [ ] Links verified
- [ ] Templates added/updated

## Measures
<how we’ll know this is working>

## Review Cadence
<when to revisit>

## Screenshots (optional)
