### PR TITLE
fix heredoc argument expansion in scaffold_safe

### DIFF
--- a/scripts/scaffold_safe.sh
+++ b/scripts/scaffold_safe.sh
@@ -12,8 +12,8 @@ create_if_missing () {
   else
     echo "➕ creating: $path"
     # shellcheck disable=SC2129
-    cat > "$path" <<'EOF'
-'"$@"'
+    cat > "$path" <<EOF
+$@
 EOF
   fi
 }


### PR DESCRIPTION
## Summary
- fix `create_if_missing` so its here-document expands arguments directly

## Testing
- `make check`
- `bash -c 'source <(head -n 20 scripts/scaffold_safe.sh); create_if_missing /tmp/testfile $'"'"'# Title\nLine 2'"'"'; cat /tmp/testfile'`


------
https://chatgpt.com/codex/tasks/task_e_68a692841b788331a4ed54535f98644e