### PR TITLE
New: Harm & Repair — Constella's non-judicial approach to harm

### DIFF
--- a/docs/governance/harm_and_repair.md
+++ b/docs/governance/harm_and_repair.md
@@ -34,7 +34,7 @@ gets defined at all).
 how they *act on themselves* are the same right. Minimal headroom only for chaotic misunderstanding — never
 a moral veto.
 
-**3. Other-regarding harm** (a cost imposed on another). Response = the **[Penumbra Accord](Penumbra_Accord.md)**
+**3. Other-regarding harm** (a cost imposed on another). Response = the **[Penumbra Accord](penumbra_accord.md)**
 (restorative, not punitive), with one **refinement**: *reintegration restores the **self** and full
 standing — it need not return the person to the same context.* Redirect to a **healing niche** (e.g. quiet
 holistic / teaching centers, self-first), which must be a **real niche with a path** — never a prison with

--- a/docs/governance/harm_and_repair.md
+++ b/docs/governance/harm_and_repair.md
@@ -1,0 +1,65 @@
+# Harm & Repair
+
+*Constella's approach to harm — deliberately **not** a justice system. Draft (2026-07-11), for Jonathan's
+revision; this is where the heart comes in.*
+
+## Design commitment: no moral high ground
+
+Constella minimizes the judicial layer **on purpose.** It avoids the language of *justice, right/wrong,
+chivalry, religion, moral norm* — for two reasons, one felt and one earned:
+
+- **The high ground is where conflict starts, not ends.** Setting a single societal moral standard creates
+  the very separation it means to prevent: *"people justified within their own bias is what is going to
+  blind the world in rage"* (Jonathan). Nothing has stayed "normal" for 50 years; a fixed norm is a false
+  floor.
+- **A moral monoculture is brittle — by the sandbox's own receipts.** One imposed standard is a *uniform
+  environment*: it **converges** and loses resilience (`niche-maintains-diversity`, convergence-is-brittle).
+  Human moral *contradiction* is not a defect to correct; it is the diversity that keeps the system alive.
+
+So Constella does not adjudicate souls. It does three humbler, buildable things: **make harm observable,
+protect the dignity of choice, and enable repair + a way forward.**
+
+## The harm gradient
+
+Harm is not black-and-white. The response scales with *who bears the cost* — never with moral rank.
+
+**1. Inherited / historical harm** (e.g. the Bracero program; generational trauma). Not the fault of those
+who carry it. Response = **observability, not blame** — a *monitored-events ledger* (the confirmability
+discipline applied to *history*) that makes trauma **legible** so it can be **owned** and met with programs
+toward a way forward. You locate the *middle* of a society by observing its two extremes — the truly
+privileged and the truly downtrodden; the ledger is how you see them (this is also how the middle band
+gets defined at all).
+
+**2. Self-regarding vice / self-harm.** Protected by the **dignity of choice.** How a person *lives* and
+how they *act on themselves* are the same right. Minimal headroom only for chaotic misunderstanding — never
+a moral veto.
+
+**3. Other-regarding harm** (a cost imposed on another). Response = the **[Penumbra Accord](Penumbra_Accord.md)**
+(restorative, not punitive), with one **refinement**: *reintegration restores the **self** and full
+standing — it need not return the person to the same context.* Redirect to a **healing niche** (e.g. quiet
+holistic / teaching centers, self-first), which must be a **real niche with a path** — never a prison with
+a nicer name. The receipt (`reintegration-over-exclusion`, C2) warns only against exclusion that *loses the
+person*; relocation to a genuine niche is not that.
+
+**4. Extreme harm** (mass atrocity). Here the frameworks — and honestly, humanity — run out. Constella's
+rule is to **pre-decide the *process*, never the *outcome*:** a convened deliberative body, case by case,
+no algorithm and no pre-set verdict. The constitution **encodes the conflict** ("this class requires
+deliberation, not a rule") rather than faking a certainty no one has. *(Note: "the choice for execution"
+splits into two different questions — the harm-doer choosing their own end, vs. society imposing it.
+Constella does not conflate them, and answers neither here.)*
+
+## Tiers (earned / asserted / beyond)
+
+- **Receipt-backed:** restorative beats punitive (`reintegration-over-exclusion`, C2); a niche maintains
+  diversity where a uniform standard converges (`niche-maintains-diversity`, C4); harm *ignored* collapses
+  the community (C2 `none` arm, 1/10 survival).
+- **Asserted values:** the refusal of the moral high ground; the dignity of choice; observability over blame.
+- **Beyond the system (irreducibly human):** the extreme band. Named, not solved — and the not-solving is
+  honest, not a gap.
+
+## Bigger project (flagged, not done)
+
+A comparative deep-dive of **real-world policies from around the world** — what each did, the outcomes, and
+how resolution was *delegated or resolved* — would ground this with evidence rather than intuition. That is
+a substantial separate effort (banked in the roadmap), and it is how the gradient above earns its receipts
+in human systems instead of only in the sandbox.


### PR DESCRIPTION
**Draft for your revision** — crystallizes today's frame. The load-bearing move: **Constella minimizes the judicial layer on purpose** (no "justice"/moral-high-ground), because a fixed moral norm creates the separation it means to prevent, and a moral monoculture is brittle by the sandbox's own `niche-maintains-diversity` / convergence findings. It does three humbler things: **make harm observable, protect the dignity of choice, enable repair + a way forward.**

## The harm gradient (response scales with *who bears the cost*, not moral rank)
1. **Inherited/historical harm** (Bracero, generational trauma) → *observability ledger, not blame*; locate the middle by observing the two extremes.
2. **Self-regarding vice** → *dignity of choice.*
3. **Other-regarding harm** → *Penumbra restorative* + refinement: **reintegration restores the *self*, not the old context** → a healing niche (a real niche, not a prison).
4. **Extreme harm** → *pre-decide the process, never the outcome* — deliberation, no algorithm; **encode the conflict** rather than fake certainty.

Tiers marked (receipt-backed / asserted / beyond-the-system). Flags the bigger comparative world-policy deep-dive as a future project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)