### PR TITLE
Presentation + review system: current README, REVIEW.md, coherence checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,27 +22,49 @@ trail. Constella's core move is **attestation**: every claim carries a tier —
 when independent sources corroborate. Governance, money, and identity are all rebuilt on
 that one honesty rule.
 
+## What makes this different: earned, not asserted
+
+Most governance proposals are essays — principles asserted from the armchair. Constella runs an **ALife
+sandbox** (the companion [`alife`](https://github.com/Nightmarejam/alife) repo: a bit-exact, deterministic
+Rust simulation) that *earns* its principles as **reproducible receipts.** Each design claim is tested
+across many random seeds; it becomes a **confirmed word** only if it reproduces — and it is honestly marked
+**refuted** if it doesn't (the retired "89.2%" figure is kept and struck, never hidden).
+
+~16 confirmed words back the constitution today — e.g. *civic-floor → resilience*, *reintegration beats
+exclusion*, *a persistent niche maintains the diversity a uniform standard converges away* — each with its
+boundary conditions and a runnable command. The [evidence bridge](docs/governance/alife_evidence_mapping.md)
+maps every claim to its receipt at **zero drift.** It is the framework's own honesty rule applied to
+itself: a claim is only as strong as its receipt.
+
 ## The concepts, one at a time
 
 Read in this order — each builds on the last:
 
-1. **[Founding hypothesis](docs/governance/founding_hypothesis.md)** — the honest
-   starting assumption (labeled *unprovable* on purpose, not hidden).
-2. **[Confirmability / the attestation layer](docs/reference/confirmability.md)** — the
-   epistemic floor: tiers, receipts, precedence. The one idea everything else inherits.
-3. **[Tokens — Astris & Auctor](docs/governance/tokens_astris_auctor.md)** — participation
-   (outward) and accountability (grounding); a system needs both or it starves or drifts.
-4. **[Universal Civic Floor](docs/governance/ucf.md)** — a baseline of dignity, denominated
-   in **joules** (energy already spent), not fiat.
-5. **[Penumbra Accord](docs/governance/penumbra_accord.md)** — how dissent is turned into
-   accountability instead of treated as failure.
-6. **[Proof of Life](rfcs/001-proof-of-life-consensus.md)** + **[PoW basis & attestation](rfcs/002-pow-basis-and-attestation.md)**
+1. **[Founding hypothesis](docs/governance/founding_hypothesis.md)** — the honest starting assumption
+   (labeled *unprovable* on purpose, not hidden).
+2. **[Confirmability / the attestation layer](docs/reference/confirmability.md)** — the epistemic floor:
+   tiers, receipts, precedence. The one idea everything else inherits.
+3. **[Tokens — Astris & Auctor](docs/governance/tokens_astris_auctor.md)** — participation (outward) and
+   accountability (grounding); a system needs both or it starves or drifts.
+4. **[Universal Civic Floor](docs/governance/ucf.md)** — a baseline of dignity, denominated in **joules**
+   (energy already spent), not fiat. Its sibling: the **[Temporal Floor](docs/governance/temporal_floor.md)**
+   — a floor on *time* (the right to fallow time), against attention-extraction.
+5. **[Penumbra Accord](docs/governance/penumbra_accord.md)** — dissent turned into accountability — extended
+   by **[Harm & Repair](docs/governance/harm_and_repair.md)**, a deliberately *non-judicial* harm gradient
+   (Constella refuses the moral high ground).
+6. **[Governance Cadence](docs/governance/governance_cadence.md)** — the loose, multi-zone rhythm the polity
+   runs on, so people can anticipate cheaply and never be forced.
+7. **[Observability Layer](docs/governance/observability_layer.md)** + **[Civic Tome](docs/governance/civic_tome.md)**
+   — how Constella *sees* (count → condition, with a privacy dial) and *records* (a confirmable, tiered ledger).
+8. **[Proof of Life](rfcs/001-proof-of-life-consensus.md)** + **[PoW basis & attestation](rfcs/002-pow-basis-and-attestation.md)**
    — identity as *verified human presence*, secured by hardware attestation, not raw compute.
-7. **[Constella–Harmony Bridge](harmony/docs/constella_harmony_bridge_v1.0.0.md)** — why
-   the civic architecture and a body-resonance model turn out to be the same shape.
+9. **[Constella–Harmony Bridge](harmony/docs/constella_harmony_bridge_v1.0.0.md)** — why the civic
+   architecture and a body-resonance model turn out to be the same shape.
+10. **[The Adaptive Loop](docs/governance/adaptive_loop.md)** — the capstone: how sandbox → constitution →
+    record → dataset → model → **self-amendment** closes into a loop (the model *proposes*, humans *decide*).
 
-Two reference docs tie it together: **[concept lineage](docs/reference/concept_lineage.md)**
-(how each idea traces from origin to today) and the confirmability schema above.
+The **[canonical index](docs/governance/INDEX.md)** lists every spec with its status; **[concept lineage](docs/reference/concept_lineage.md)**
+traces each idea from origin to today.
 
 ## Status & scope (honest)
 
@@ -51,14 +73,17 @@ Two reference docs tie it together: **[concept lineage](docs/reference/concept_l
 - The founding hypothesis is an honest assumption, not a proven claim.
 - Work tagged `speculative` (much of the attestation, PET-device, and chain material) is
   **thinking on paper** — the tiers tell you what's what.
-- Core design pass is 5/6 complete; the remaining item waits on live telemetry. See
-  [STATUS.md](STATUS.md).
+- The structural design work is at a natural completeness (see [STATUS.md](STATUS.md)); the current
+  frontier is the training dataset (gated by hardware) and grounding the newer value-boundaries in real
+  cases (the [comparative deep-dive](docs/reference/real_world_harm_cases.md), just begun).
 
-## Contributing & structure
+## Contributing, structure & review
 
 - **How to contribute:** [CONTRIBUTING.md](CONTRIBUTING.md)
+- **Reviewing this repo:** [REVIEW.md](REVIEW.md) — the coherence + honesty checklist, plus CI
+  (markdownlint / codespell / lychee) and `scripts/check_coherence.sh`.
 - **Living docs** vs. **frozen version snapshots**: `docs/constella/` vs `docs/frameworks/`
-- **Governance index:** `docs/governance/` · **Vision:** `docs/vision/` · **RFCs:** `rfcs/`
+- **Governance index:** [`docs/governance/INDEX.md`](docs/governance/INDEX.md) · **Vision:** `docs/vision/` · **RFCs:** `rfcs/`
 
 ---
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,61 @@
+# Review System
+
+*How this repository keeps itself coherent, current, and honest — the same attestation discipline the
+framework proposes for a polity, turned on the repo itself. Run this pass before sharing the project or
+cutting a release.*
+
+## Why this exists
+
+Constella's core claim is that systems drift when claims get treated as fact without a checkable receipt.
+A framework that says that must **hold itself to it.** This review system is how: it keeps every doc
+indexed, every link live, every claim tiered, and the front page current — so a reviewer finds a
+consistent, honest project rather than a pile of drafts.
+
+## 1. Automated (runs in CI + one local script)
+
+Every pull request runs **`.github/workflows/docs-ci.yml`**:
+
+- **markdownlint** — style consistency (`.markdownlint.json`).
+- **codespell** — spelling (`.codespellignore` for intentional terms, e.g. *fallow*).
+- **lychee** — every link resolves (catches broken cross-references and filename-case bugs).
+
+And **`scripts/check_coherence.sh`** (run locally; can be wired into CI) adds the content checks a linter
+can't see:
+
+1. every governance spec in `docs/governance/` is listed in the canonical `INDEX.md` (nothing orphaned);
+2. every file the `README.md` links to exists;
+3. tier honesty — flags any doc carrying both a `stable` claim and an unresolved `[verify]` for a
+   hand-check.
+
+## 2. Coherence checklist (manual, ~5 min)
+
+- [ ] `docs/governance/INDEX.md` lists every spec, each with a current status.
+- [ ] `README.md`'s "read in this order" reflects the newest layer (a reviewer starts here).
+- [ ] `STATUS.md` date is current and its "Where we are" matches reality.
+- [ ] `adaptive_loop.md` (the capstone) still describes the actual pipeline.
+- [ ] The GitHub repo **description + topics** match the content.
+
+## 3. Honesty / logic audit (the differentiator)
+
+This is the part that earns a reviewer's trust:
+
+- [ ] **Every claim carries a tier** — `confirmed` / `asserted` / `speculative` (attestation), or the
+      Civic Tome's `stable` / `contested` / `speculative`.
+- [ ] **No `confirmed`/`stable` claim without a receipt** — a reproducible sandbox word (in the alife repo)
+      or a cited primary source.
+- [ ] **`[verify]` flags are not promoted** past `contested`.
+- [ ] **Earned vs asserted vs beyond** are separated in each doc — sandbox-derived, values-asserted, and
+      irreducibly-human are never blurred.
+- [ ] **Refuted claims are marked, never silently deleted** (e.g. the retired "89.2%" figure).
+
+## 4. Currency (per working session)
+
+- [ ] New docs added to both `INDEX.md` and `README.md`.
+- [ ] Resolved `INDEX.md` issues marked; open ones stated honestly.
+- [ ] **Cross-repo sync at zero drift:** the alife repo's `CONSTELLA_TO_EXPERIMENTS.md` (receipts) ↔ this
+      repo's `docs/governance/alife_evidence_mapping.md` (claims). Every earned word appears in both.
+
+## The one-liner
+
+**The review system *is* the thesis.** Nothing in this repo should read as more certain than its receipts
+allow — and this pass is how we keep that true.

--- a/scripts/check_coherence.sh
+++ b/scripts/check_coherence.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# check_coherence.sh — content-coherence checks for the Constella framework.
+#
+# Complements the CI (docs-ci.yml: markdownlint + codespell + lychee link-check) with the
+# *content* checks a reviewer cares about but a linter can't see:
+#   1. every governance spec is listed in the canonical INDEX (nothing orphaned)
+#   2. every file the README links to actually exists
+#   3. tier honesty — flag any doc that carries both a `stable` claim and an unresolved `[verify]`
+#
+# Run from anywhere:  ./scripts/check_coherence.sh   (exit 0 = coherent)
+set -uo pipefail
+cd "$(dirname "$0")/.."
+fail=0
+
+echo "== 1. INDEX coverage: every governance spec listed in docs/governance/INDEX.md =="
+for f in docs/governance/*.md; do
+  b=$(basename "$f")
+  [[ "$b" == "INDEX.md" || "$b" == "README.md" ]] && continue
+  if ! grep -qi "$b" docs/governance/INDEX.md; then   # case-insensitive: git tracks lowercase
+    echo "  ✗ not listed in INDEX: $b"; fail=1
+  fi
+done
+[[ $fail -eq 0 ]] && echo "  ✓ all governance specs indexed"
+
+echo "== 2. README link integrity: every relative .md link resolves =="
+rfail=0
+while IFS= read -r link; do
+  [[ "$link" == http* ]] && continue
+  [[ -f "$link" ]] || { echo "  ✗ broken README link: $link"; rfail=1; fail=1; }
+done < <(grep -oE '\]\([^)]+\.md' README.md | sed -E 's/^\]\(//')
+[[ $rfail -eq 0 ]] && echo "  ✓ all README .md links resolve"
+
+echo "== 3. tier honesty: docs carrying both 'stable' and an unresolved [verify] =="
+hits=$(grep -rlE '\[verify\]' docs/ 2>/dev/null | xargs grep -lw 'stable' 2>/dev/null || true)
+if [[ -n "$hits" ]]; then
+  echo "  ⚠ review by hand (a stable claim should not sit next to an unverified figure):"
+  echo "$hits" | sed 's/^/    - /'
+else
+  echo "  ✓ no stable-tier doc has an unresolved [verify]"
+fi
+
+echo
+if [[ $fail -eq 0 ]]; then echo "✅ COHERENCE OK"; else echo "⚠️ COHERENCE ISSUES (see above)"; fi
+exit $fail


### PR DESCRIPTION
For presenting Constella to project reviewers — makes the repo current and professional, and builds the repeatable review system you asked for.

## 1. README — current + leads with the differentiator
- New **"What makes this different: earned, not asserted"** section — the **ALife sandbox** that *earns* principles as reproducible receipts (~16 confirmed words, refuted ones marked, zero-drift evidence bridge). This is the most credible, reviewer-facing feature and it was previously invisible in the README.
- The concept list (was 1–7, ending at the Harmony bridge) now includes the **entire recent layer**: Temporal Floor, Harm & Repair, Governance Cadence, Observability Layer + Civic Tome, and the **Adaptive Loop** capstone.
- Fixed the stale "5/6 core pass" status → current frontier.

## 2. `REVIEW.md` — the review system
CI (markdownlint / codespell / lychee) + `scripts/check_coherence.sh` + a manual coherence checklist + an **honesty/logic audit** (every claim tiered; no `stable` without a receipt; refuted claims marked, never deleted) + per-session currency. *"The review system is the thesis"* — the attestation discipline turned on the repo itself.

## 3. `scripts/check_coherence.sh`
Content checks a linter can't see: every governance spec in the INDEX, every README link resolves, tier-honesty heuristic. **Caught a real filename-case mismatch on its first run.** Passes clean now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)